### PR TITLE
Bug 2272: Change infra to handle callback after middleware job is done.

### DIFF
--- a/src/serverroot/jobs/core/redisPub.js
+++ b/src/serverroot/jobs/core/redisPub.js
@@ -35,34 +35,15 @@ function doSetToRedis (key, data)
 	});
 }
 
-function publishDataToRedisWithPostCb (jobData, errCode, pubData, saveData,
-                                       doSave, expiryTime, done)
-{
-    var taskData = jobData.taskData;
-    var pubChannel = taskData['pubChannel'];
-    var saveChannelKey = taskData['saveChannelKey'];
-    var postCbSet = taskData['postCbSet'];
-
-    return publishDataToRedis(pubChannel, saveChannelKey, errCode, pubData,
-                              saveData, doSave, expiryTime, done, postCbSet);
-}
-
 function publishDataToRedis (pubChannel, saveChannelKey, errCode, pubData, 
-                             saveData, doSave, expiryTime, done, jobData, postCbSet)
+                             saveData, doSave, expiryTime, done, jobData)
 {
     var curTime = commonUtils.getCurrentTimestamp();
 
-    if (null == postCbSet) {
-        postCbSet = 0;
-    } else {
-        postCbSet = parseInt(postCbSet);
-    }
-
-    var pubDataObj = {
-        errCode:errCode,
-        postCbSet:postCbSet,
-        data:(pubData)
-    };
+	var pubDataObj = {
+		errCode:errCode,
+		data:(pubData)
+	};
     /*
      Will enable genertic data format later, once all the frontend code also can 
      handle this data format
@@ -128,5 +109,4 @@ exports.sendRedirectRequestToMainServer = sendRedirectRequestToMainServer;
 exports.publishDataToRedis = publishDataToRedis;
 exports.createChannelByHashURL = createChannelByHashURL;
 exports.createRedisPubClient = createRedisPubClient;
-exports.publishDataToRedisWithPostCb = publishDataToRedisWithPostCb;
 

--- a/src/serverroot/web/core/cache.api.js
+++ b/src/serverroot/web/core/cache.api.js
@@ -126,13 +126,8 @@ function queueDataFromCacheOrSendRequest (req, res, jobType, jobName,
                                           sendToJobServerAlways, appData,
                                           postCallback)
 {
-    var postCbSet = 0;
-    if (null != postCallback) {
-        postCbSet = 1;
-    }
 	var reqData = createReqData(req, jobType, jobName, reqUrl, jobRunCount,
-		defCallback, firstRunDelay, nextRunDelay, appData, global.REQ_BY_UI,
-        postCbSet);
+		defCallback, firstRunDelay, nextRunDelay, appData, global.REQ_BY_UI);
 	var reqJSON = JSON.parse(reqData);
 	var reqUrl = reqJSON.data.url;
 	var hash = reqJSON.jobName;
@@ -297,7 +292,7 @@ function queueDataFromCacheOrSendRequestByReqObj (reqObj)
  if defCallback: 0, define the callback in job process section
  */
 function createReqData (req, type, jobName, reqUrl, runCount, defCallback, 
-                        firstRunDelay, nextRunDelay, appData, reqBy, postCbSet)
+                        firstRunDelay, nextRunDelay, appData, reqBy)
 {
     var authObj = {
         /* authObj contains all the auth related parameters, which may be needed
@@ -328,7 +323,6 @@ function createReqData (req, type, jobName, reqUrl, runCount, defCallback,
 			pubChannel: pubChannel,
 			saveChannelKey: saveChannelKey,
 			reqBy: reqBy,
-			postCbSet: postCbSet,
 			appData: appData
 		}
 	};


### PR DESCRIPTION
Earlier any response coming from JobServer was directly being sent to UI by the
infra without bothering about App.
Added mechanism to handle the response of the jobServer and if APP needs to
process the response and send to UI, can add a callback before sending to
jobServer, once response comes, the callback will be called with req, resp
object and response data from jobServer.
