### PR TITLE
Removed "tenants/monitor/network" from base URL as URL remains same

### DIFF
--- a/src/serverroot/orchestration/plugins/cloudstack/cloudstack.authApi.js
+++ b/src/serverroot/orchestration/plugins/cloudstack/cloudstack.authApi.js
@@ -121,7 +121,7 @@ function authenticate (req, res, callback)
                               '; expires=' +
                               new Date(new Date().getTime() +
                                        global.MAX_AGE_SESSION_ID).toUTCString());
-                res.redirect('/tenants/monitor/network' + urlHash);
+                res.redirect('/' + urlHash);
             });
         });
     });

--- a/src/serverroot/orchestration/plugins/openstack/keystone.api.js
+++ b/src/serverroot/orchestration/plugins/openstack/keystone.api.js
@@ -524,7 +524,7 @@ function authenticate (req, res, callback)
                                   '; expires=' + 
                                   new Date(new Date().getTime() +
                                            global.MAX_AGE_SESSION_ID).toUTCString());
-                    res.redirect('/tenants/monitor/network' + urlHash);
+                    res.redirect('/' + urlHash);
                 });
             });
         });

--- a/src/xml/parseURL.xml
+++ b/src/xml/parseURL.xml
@@ -120,7 +120,7 @@
         <callback>handler.admin</callback>
     </item>
     <item>
-        <url>/tenants/monitor/network</url>
+        <url>/</url>
         <method>get</method>
         <feature>monitoring</feature>
         <callback>handler.dashboard</callback>


### PR DESCRIPTION
while navigating across all features through menu
