### PR TITLE
Fixing an issue where the URLs were getting added as params to the same url.

### DIFF
--- a/webroot/js/web-utils.js
+++ b/webroot/js/web-utils.js
@@ -1299,23 +1299,24 @@ function flattenArr(arr) {
 $.deparam = function (query) {
     var query_string = {};
     var query = ifNull(query,'');
-    if (query.indexOf('?') > -1)
+    if (query.indexOf('?') > -1) {
         query = query.substr(query.indexOf('?') + 1);
-    var vars = query.split("&");
-    for (var i = 0; i < vars.length; i++) {
-        var pair = vars[i].split("=");
-        pair[0] = decodeURIComponent(pair[0]);
-        pair[1] = decodeURIComponent(pair[1]);
-        // If first entry with this name
-        if (typeof query_string[pair[0]] === "undefined") {
-            query_string[pair[0]] = pair[1];
-            // If second entry with this name
-        } else if (typeof query_string[pair[0]] === "string") {
-            var arr = [ query_string[pair[0]], pair[1] ];
-            query_string[pair[0]] = arr;
-            // If third or later entry with this name
-        } else {
-            query_string[pair[0]].push(pair[1]);
+        var vars = query.split("&");
+        for (var i = 0; i < vars.length; i++) {
+            var pair = vars[i].split("=");
+            pair[0] = decodeURIComponent(pair[0]);
+            pair[1] = decodeURIComponent(pair[1]);
+            // If first entry with this name
+            if (typeof query_string[pair[0]] === "undefined") {
+                query_string[pair[0]] = pair[1];
+                // If second entry with this name
+            } else if (typeof query_string[pair[0]] === "string") {
+                var arr = [ query_string[pair[0]], pair[1] ];
+                query_string[pair[0]] = arr;
+                // If third or later entry with this name
+            } else {
+                query_string[pair[0]].push(pair[1]);
+            }
         }
     }
     return query_string;


### PR DESCRIPTION
This was a bug in the deparam utility. When there were no params
this was returning the url as the param. Fixed by now returning empty
object if there are no params in the url.
