### PR TITLE
Fix for the bug 2682 - Showing wrong name in error popup while deleting ...

### DIFF
--- a/src/tools/cutils.js
+++ b/src/tools/cutils.js
@@ -871,7 +871,7 @@ function deleteComplete(cbParams) {
     	var msg = "";
     	var objects = [];
         for(var i=0; i<cbParams.errors.length; i++) {
-            objects[i] = cbParams.selected_rows[i][cbParams.errorField];
+            objects[i] = cbParams.selected_rows[cbParams.errors[i]][cbParams.errorField];
             msg = msg +
             cbParams.errorField + ": " + cbParams.selected_rows[i][cbParams.errorField] + "<br>" +
             cbParams.errorDesc[i] + "<br><br>";


### PR DESCRIPTION
...all the rows from grid and any one row not matching delete criteria
