### PR TITLE
R1.05: Handling keywords 'any' and 'local' along with VNs with names 'any' and 'local' in all case letters

### DIFF
--- a/src/tools/cutils.js
+++ b/src/tools/cutils.js
@@ -257,7 +257,12 @@ function policy_net_display(nets, domain, project) {
                 		isString(project)) {
                 		var splits = net["virtual_network"].split(":");
                 		if(domain === splits[0] && project === splits[1]) {
-                			net_disp += splits[2];
+                            if(splits[2].toLowerCase() === "any" || 
+                                splits[2].toLowerCase() === "local"){
+                                net_disp = net["virtual_network"].toString();
+                            } else {
+                               net_disp += splits[2];
+                            }
                 		} else {
                 			net_disp += net["virtual_network"].toString();
                 		}


### PR DESCRIPTION
Handling keywords 'any' and 'local' along with VNs with names 'any' and 'local' in all case letters
