### PR TITLE
Partial fix for Bug : 3078 - :Introspect links are not showing proper content.

### DIFF
--- a/webroot/universal_parse.xsl
+++ b/webroot/universal_parse.xsl
@@ -49,7 +49,7 @@
 			   				var proxyURL = getProxyURL();
 							document.getElementById('proxyURL_' + req).value=proxyURL + '/Snh_' + req  ;
 							//alert(document.getElementById('proxyURL_' + req).value);
-							this.submit();
+							return true;
 						};
 						
 						function onLinkClick(params){
@@ -208,7 +208,7 @@
                             <input id="proxyURL_{$reqx}" type="hidden" value="" name="proxyURL"></input>
                             <div class="control-group">
                                 <div class="controls">
-                                    <button class="btn btn-small btn-primary" 
+                                    <button type="submit" class="btn btn-small btn-primary" 
                                     		onclick="setURL('{$reqx}');">
 													Send
 									</button>


### PR DESCRIPTION
form.submit() is no longer supported in IE 10. Changed it to just return
true so that the form submits itself. 

Another part of the fix has to be done at the back in the way they send
the xmls. for eg. agent.xml
