### PR TITLE
1. Moved common templates used in dashboard to core repo (webroot/views/...

### DIFF
--- a/webroot/js/chart-utils.js
+++ b/webroot/js/chart-utils.js
@@ -126,7 +126,10 @@
 
 
             chartOptions['elementClickFunction'] = function (e) {
-                processDrillDownForNodes(e);
+                if(typeof(chartOptions['clickFn']) == 'function')
+                    chartOptions['clickFn'](e['point']);
+                else
+                    processDrillDownForNodes(e);
             };
             chartOptions['elementMouseoutFn'] = function (e) {
                 if(e['point']['overlappedNodes'] != undefined && e['point']['overlappedNodes'].length > 1) {
@@ -159,19 +162,6 @@
             if(data['widgetBoxId'] != null)
                 endWidgetLoading(data['widgetBoxId']);
 
-            function nodeTooltipFn(e,x,y,chart,tooltipFn) {
-                var result = {};
-                    //markOverlappedBubblesOnHover reuturns Overlapped nodes in ascending order of severity
-                    //Reverse the nodes such that high severity nodes are displayed first in the tooltip 
-                    e['point']['overlappedNodes'] = markOverlappedBubblesOnHover(e,chart).reverse();
-                    if(e['point']['overlappedNodes'] == undefined || e['point']['overlappedNodes'].length <= 1) {
-                        return formatLblValueTooltip(tooltipFn(e));
-                    } else if(e['point']['multiTooltip'] == true) {
-                        result = getMultiTooltipContent(e,tooltipFn,chart);
-                        result['content'] = result['content'].slice(0,result['perPage']);
-                        return formatLblValueMultiTooltip(result);
-                    }
-            }
             /**
              * function takes the parameters tooltipContainer object and the tooltip array for multitooltip and binds the 
              * events like drill down on tooltip and click on left and right arrows

--- a/webroot/js/web-utils.js
+++ b/webroot/js/web-utils.js
@@ -1358,43 +1358,6 @@ function reloadGrid(grid){
 	grid.refreshData();
 }
 
-/**
- * Template to show the tooltip on grid cells
- */
-function cellTemplate(options) {
-    var name = null, nameStr = '', cellText = '', titleStr = '', nameCls = '', tooltipCls = '', onclickAction = '',colorCls = '';
-    if (options == null)
-        options = {};
-    name = ifNull(options['name'], name);
-    cellText = ifNull(options['cellText'], cellText);
-    //Assign title attribute only if tooltipCls is present
-    if ((cellText != null) && (cellText.indexOf('#') != 0))
-        cellText = '#=' + cellText + '#';
-    var tooltipText = cellText;
-    tooltipText = ifNull(options['tooltipText'], tooltipText);
-
-    if (name != null) {
-        nameStr = 'name="' + name + '"';
-        nameCls = 'cell-hyperlink';
-    }
-    if ((options['tooltip'] == true) || (options['tooltipText'] != null) || (options['tooltipFn'] != null)) {
-        tooltipCls = 'mastertooltip';
-        if (options['tooltipFn'] != null) {
-            titleStr = 'title="#=tooltipFns.' + options['tooltipFn'] + '(data)#"';
-        } else
-            titleStr = 'title="' + tooltipText + '"';
-    }
-    if (options['onclick'] != null) {
-        onclickAction = 'onclick="' + options['onclick'] + '"';
-    }
-    if (options['applyColor']){
-        colorCls = '#=decideColor(\'{1}\',hostNameColor)#';
-    } else {
-        colorCls = nameCls;
-    }
-    return contrail.format("<div class='{1} {5}' {0} {2} {4}>{3}</div>", nameStr, tooltipCls, titleStr, cellText, onclickAction, colorCls);
-}
-
 /* 
  * Function to style links on grid cell
  */
@@ -1817,15 +1780,7 @@ function showMoreAlerts(){
  */
 
 function processDrillDownForNodes(e) {
-     if (e['point']['type'] == 'vRouter') {
-         layoutHandler.setURLHashParams({node:e['point']['name'], tab:''}, {p:'mon_infra_vrouter'});
-     } else if (e['point']['type'] == 'controlNode') {
-         layoutHandler.setURLHashParams({node:e['point']['name'], tab:''}, {p:'mon_infra_control'});
-     } else if (e['point']['type'] == 'analyticsNode') {
-         layoutHandler.setURLHashParams({node:e['point']['name'], tab:''}, {p:'mon_infra_analytics'});
-     } else if (e['point']['type'] == 'configNode') {
-         layoutHandler.setURLHashParams({node:e['point']['name'], tab:''}, {p:'mon_infra_config'});
-     } else if (e['point']['type'] == 'network') {
+     if (e['point']['type'] == 'network') {
          layoutHandler.setURLHashParams({fqName:e['point']['name']}, {p:'mon_net_networks'});
      } else if (e['point']['type'] == 'project') {
          layoutHandler.setURLHashParams({fqName:e['point']['name']}, {p:'mon_net_projects'});

--- a/webroot/views/contrail-common.view
+++ b/webroot/views/contrail-common.view
@@ -371,3 +371,108 @@
 <!--
     End:Dashboard templates
 -->
+<script type="text/x-handlebars-template" id="widget-header-template">
+        <h4 class="smaller">
+            {{#if widgetBoxId}}
+                <i id="{{widgetBoxId}}-loading" class="icon-spinner icon-spin blue bigger-125" style="display:none"></i> 
+            {{/if}}
+            <span>{{title}}</span>
+        </h4>
+
+        <div class="widget-toolbar pull-right">
+            <a data-action="collapse">
+                <i class="icon-chevron-up"></i>
+            </a>
+        </div>
+</script>
+<script type="text/x-handlebars-template" id="gridsTemplateJSONDetails">
+    <div>
+        <div class="row-fluid">
+            <div class="row-fluid">
+                <label>Details :</label>
+            </div>
+            <div class="row-fluid">
+                <div><pre>{{{displayJson raw_json}}}</pre></div>
+            </div>
+        </div>
+   </div>
+</script>
+<script type="text/x-handlebars-template" id = "overallNodeStatusTemplate">
+    <div id = "overallNodeStatus">
+        <div id = "allItems" class="hide">
+            {{#each this.result}}
+                <p style="margin: 0 0 0 0">
+                    {{#IfCompare sevLevel null operator='!='}}
+                        {{#renderStatusTemplate sevLevel}}{{/renderStatusTemplate}}
+                    {{/IfCompare}}
+                    {{msg}}
+                </p>
+            {{/each}}
+            <span onclick="toggleOverallNodeStatus(['#allItems','#defaultItems']);"> hide</span>
+        </div>
+        {{#IfCompare this.showMore true}}
+            <div id = "defaultItems">
+                {{#each this.result}}
+                    <p style="margin: 0 0 0 0">
+                        {{#IfCompare @index ../defaultItems operator='<'}}
+                            {{#IfCompare sevLevel null operator='!='}}
+                                {{#renderStatusTemplate sevLevel}}{{/renderStatusTemplate}}
+                            {{/IfCompare}}
+                            {{msg}}
+                        {{/IfCompare}}
+                    </p>
+                {{/each}}  
+                {{#IfCompare this.result.length this.defaultItems operator='>'}}
+                    <span onclick="toggleOverallNodeStatus(['#allItems','#defaultItems']);"> {{#ArthematicOps this.result.length this.defaultItems operator='-'}}
+                    {{/ArthematicOps}} more</span>
+               {{/IfCompare}}
+            </div>
+        {{/IfCompare}}
+    </div>
+</script>
+
+<script type = "text/x-handlebars-template" id = "statusTemplate">
+    {{#IfCompare sevLevel sevLevels.ERROR }} 
+        <span class="status-badge-rounded-small status-inactive"></span>
+    {{else}}
+        {{#IfCompare sevLevel sevLevels.WARNING}} 
+            <span class="status-badge-rounded-small status-partially-active"></span>
+        {{/IfCompare}}
+    {{/IfCompare}}
+</script>
+
+<script type="text/x-handlebars-template" id="dashboard-body-template">
+    <div class="widget-main row-fluid">
+            {{#IfCompare showSettings true options='=='}}
+                <div id="divAdvanced" class="row-fluid hide">
+                    <div><pre>{{{displayJson nodeData}}}</pre></div>
+                </div>
+            {{/IfCompare}}
+            <div id="divBasic" class="row-fluid">
+                <ul id="detail-columns" class="item-list">
+                    {{#each d}}
+                        <li>
+                            <label class="inline row-fluid">
+                                <div class="key span5">{{{this.lbl}}}</div>
+                                <div class="value span7"> 
+                                    {{#if this.value}}
+                                        {{{this.value}}}
+                                    {{else}}
+                                         --
+                                    {{/if}}
+                                </div>
+                            </label>
+                        </li>
+                    {{/each}} <!-- /each d -->
+                </ul>   
+            </div><!--/span-->
+            <div id="divStatus" hidden="true" class="row-fluid">
+                <div id="divContrailStatus" class="row-fluid"></div>
+                <!-- <div class="row-fluid">
+                    <label class="span3">Opentstack Status</label><i id="icon_divOpenStackStatus" class="icon-expand-alt" onclick="toggleDetails('divOpenStackStatus');"></i>
+                </div>
+                <div id="divOpenStackStatus" hidden="true" class="widget-main padding-4" class="row-fluid"></div>
+                -->
+            </div>
+    </div><!-- /widget-main --> 
+</script>


### PR DESCRIPTION
...contrail-common.view)
1. Added “clickFn” under “chartOptions” while calling initiScatterChart, which will be called once a node is clicked in scatter chart.
2. Moved getDownNodeCnt,sortInfraAlerts and sortNodesByColor are moved to dashboard-utils.js under object “dashboardUtils”.
