### PR TITLE
Revert default logo from opencontrail to juniper 

### DIFF
--- a/webServerStart.js
+++ b/webServerStart.js
@@ -355,7 +355,7 @@ function startWebCluster ()
 function doPreStartServer (isRetry)
 {
     var rootPath = path.join(__dirname, 'webroot');
-    var defLogoFile = '/img/opencontrail-logo.png';
+    var defLogoFile = '/img/juniper-networks-logo.png';
     var srcLogoFile = rootPath + defLogoFile;
 
     if ((null != config.logo_file) && (false == isRetry)) {

--- a/webroot/css/contrail.custom.css
+++ b/webroot/css/contrail.custom.css
@@ -601,6 +601,7 @@ ul.configActionMenu {
 .brand img{display:inline-block;}
 .brand img.logo{ 
 	margin-left:-5px;
+	max-width: 152px;
 	height: 40px;
 }
 .infobox > .stat{
@@ -812,6 +813,7 @@ a.selectAllLink:hover {
 .sparklines-box{
 	border: 1px solid #dedede;
 	padding: 5px;
+	cursor: pointer;
 }
 .sparklines-box p.sparkline-title{
 	padding: 0 5px 2px;


### PR DESCRIPTION
As opencontrail logo need to be shown only for dev-stack
