### PR TITLE
While loading a feature, currently, only <css> files specified for that

### DIFF
--- a/webroot/js/web-utils.js
+++ b/webroot/js/web-utils.js
@@ -1165,6 +1165,7 @@ function MenuHandler() {
                     var parentRootDir = parent['rootDir'];
                     if (parentRootDir != null && parent['view'] != null) {
                         loadViewResources(parent,currMenuObj['hash']);
+                        loadCssResources(parent,currMenuObj['hash']);
                     }
                 });
             }
@@ -1210,6 +1211,8 @@ function MenuHandler() {
         }
 
         function loadCssResources(menuObj,hash) {
+            if(menuObj['css'] == null)
+                return;
             if (!(menuObj['css'] instanceof Array)) {
                 menuObj['css'] = [menuObj['css']];
             }


### PR DESCRIPTION
feature in menu.xml are loaded.
Now, modified to load all <css> tags specified at any parent level of current feature
