### PR TITLE
Fixed performance issue with getValueByJsonPath.

### DIFF
--- a/webroot/js/web-utils.js
+++ b/webroot/js/web-utils.js
@@ -2218,7 +2218,7 @@ function toggleOverallNodeStatus(selector) {
  */
 function getValueByJsonPath(obj,pathStr,defValue) {
     try {
-    	var currObj = $.extend(true,{},obj);
+    	var currObj = obj;
         var pathArr = pathStr.split(';');
         var arrLength = pathArr.length;
         for(var i=0;i<arrLength;i++) {
@@ -2227,7 +2227,12 @@ function getValueByJsonPath(obj,pathStr,defValue) {
             } else
                 return defValue;
         }
-        return currObj;
+        if(currObj instanceof Array)
+            return $.extend(true,[],currObj);
+        else if(typeof(currObj) == "object")
+            return $.extend(true,{},currObj);
+        else
+            return currObj;
     } catch(e) {
         return defValue;
     }


### PR DESCRIPTION
Earlier, the input object is cloned at the beginning that's taking lot
of time with huge objects.
Instead, return the cloned object/array found at the given json path.
Such that if user modifies the return value of getValueByJsonPath,it won't affect original
object
