### PR TITLE
Fix for Bug 1330438 - vRouters chart in dashboard doenst refresh properly.

### DIFF
--- a/webroot/js/dashboard-utils.js
+++ b/webroot/js/dashboard-utils.js
@@ -175,6 +175,9 @@ function infraMonitorClass() {
             $(currTabContainer).show();
             //Trigger refresh on svg charts
             $(currTabContainer).find('svg').trigger('refresh');
+            if($(currTabContainer).find('svg').length > 0){
+                $(currTabContainer).find('svg').resize();
+            }
         });
 
         //When all node details are fetched,upedate alerts & info boxes


### PR DESCRIPTION
Triggering the resize() event manually on click of the tab so that the charts refresh.
