### PR TITLE
 Integrated analytics Oracle stats changes in UI,bug id is #1350680

### DIFF
--- a/src/serverroot/common/global.js
+++ b/src/serverroot/common/global.js
@@ -246,7 +246,13 @@ global.QUERY_JSON = {
     ObjectCollectorInfo: {"table": 'ObjectCollectorInfo', "start_time": "", "end_time": "", "select_fields": ["MessageTS", "Source", "ModuleId"], "sort_fields": ['MessageTS'], "sort": 2, "filter": []},
     ObjectSITable: {"table": 'ObjectSITable', "start_time": "", "end_time": "", "select_fields": ["MessageTS", "Source", "ModuleId"], "sort_fields": ['MessageTS'], "sort": 2, "filter": []},
     FlowSeriesTable: {"table": 'FlowSeriesTable', "start_time": "", "end_time": "", "select_fields": ['flow_class_id', 'direction_ing']},
-    FlowRecordTable: {"table": 'FlowRecordTable', "start_time": "", "end_time": "", "select_fields": ['vrouter', 'sourcevn', 'sourceip', 'sport', 'destvn', 'destip', 'dport', 'protocol', 'direction_ing']}
+    FlowRecordTable: {"table": 'FlowRecordTable', "start_time": "", "end_time": "", "select_fields": ['vrouter', 'sourcevn', 'sourceip', 'sport', 'destvn', 'destip', 'dport', 'protocol', 'direction_ing']},
+    StatTable_UveVirtualNetworkAgent_vn_stats: {"table": 'StatTable.UveVirtualNetworkAgent.vn_stats',"start_time": "", "end_time": "", 
+                                                "select_fields": []},
+    StatTable_VirtualMachineStats_if_stats: {"table": 'StatTable.VirtualMachineStats.if_stats',"start_time": "", "end_time": "", 
+                                                    "select_fields": []},
+    StatTable_VirtualMachineStats_fip_stats: {"table": 'StatTable.VirtualMachineStats.fip_stats',"start_time": "", "end_time": "", 
+                                                        "select_fields": []},
 };
 
 global.FORMAT_TABLE_COLUMNS = {

--- a/webroot/js/d3-utils.js
+++ b/webroot/js/d3-utils.js
@@ -499,7 +499,7 @@ function successHandlerTSChart(data, cbParams) {
     var selectorId = "#" + $(cbParams.selector).attr('id');
     var options = {
         height:300,
-        yAxisLabel: 'Bytes per 7 secs',
+        yAxisLabel: 'Bytes per 30 secs',
         y2AxisLabel: 'Bytes per min'
     };
     initTrafficTSChart(selectorId, data, options, null, "formatSumBytes", "formatSumBytes");

--- a/webroot/js/slickgrid-utils.js
+++ b/webroot/js/slickgrid-utils.js
@@ -827,6 +827,9 @@ function getDefaultGridConfig() {
                 removeGridLoading: function(){
                     gridContainer.find('.grid-header-icon-loading').hide();
                 },
+                showGridLoading: function() {
+                    gridContainer.find('.grid-header-icon-loading').show();
+                },
                 adjustAllRowHeight: function() {
                 	var self = this;
                     gridContainer.find('.slick-row-master').each(function(){

--- a/webroot/js/web-utils.js
+++ b/webroot/js/web-utils.js
@@ -197,7 +197,7 @@ var defColors = ['#1c638d', '#4DA3D5'];
                             if (chartData['link']['context'] == 'instance') {
                                 //Get the instance ip from drop-down
                                 var instObj = getSelInstanceFromDropDown();
-                                $.extend(detailObj, {ip:instObj['ip'], vnName:instObj['vnName']});
+                                $.extend(detailObj, {ip:instObj['ip_address'], vnName:instObj['virtual_network']});
                             }
                             if (chartData['class'] != null)
                                 viewObj = chartData['class'];
@@ -682,7 +682,11 @@ function prettifyBytes(obj) {
 }
 
 function formatThroughput(bytes,noDecimal,maxPrecision) {
-    return formatBytes(bytes,noDecimal,maxPrecision).replace('B','b') + 'ps';
+    var data = formatBytes(bytes,noDecimal,maxPrecision);
+    if(data != '-')
+        return data.replace('B','b') + 'ps';
+    else
+        return '-';
 }
 
 function formatBytes(bytes, noDecimal, maxPrecision, precision) {


### PR DESCRIPTION
```
- Flowseries charts in VirtualMachine, Virtual Network details page and the Inter VN stats page(When we click on the links in the topology)
- Earlier the time series charts are with 7 secs granularity and past 30mins now it is 30 secs granularity and past one hour data
- Earlier two queries were issuing for the IN & Out stats now we are getting in same query
- Added the last 1 hr tag where ever we are displaying the last one hour stats
```

Change-Id: I8afd5e6435b0f8e86046f3dbdb7202564254bf81

Conflicts:
    webroot/js/dashboard-utils.js
